### PR TITLE
Add configurable timeout to all requests

### DIFF
--- a/config/pirsch.php
+++ b/config/pirsch.php
@@ -4,6 +4,6 @@ return [
 
     'token' => env('PIRSCH_TOKEN'),
 
-    'timeout' => env('PIRSCH_TIMEOUT', 250),
+    'timeout' => env('PIRSCH_TIMEOUT', 5000),
 
 ];

--- a/config/pirsch.php
+++ b/config/pirsch.php
@@ -4,4 +4,6 @@ return [
 
     'token' => env('PIRSCH_TOKEN'),
 
+    'timeout' => env('PIRSCH_TIMEOUT', 250),
+
 ];

--- a/config/pirsch.php
+++ b/config/pirsch.php
@@ -4,6 +4,4 @@ return [
 
     'token' => env('PIRSCH_TOKEN'),
 
-    'timeout' => env('PIRSCH_TIMEOUT', 5000),
-
 ];

--- a/src/Pirsch.php
+++ b/src/Pirsch.php
@@ -18,6 +18,7 @@ class Pirsch
 
             try {
                 Http::withToken(config('pirsch.token'))
+                    ->connectTimeout(0.5)
                     ->retry(
                         times: 3,
                         sleepMilliseconds: 100,

--- a/src/Pirsch.php
+++ b/src/Pirsch.php
@@ -19,6 +19,11 @@ class Pirsch
             try {
                 Http::withToken(config('pirsch.token'))
                     ->timeout(config('pirsch.timeout'))
+                    ->retry(
+                        times: 3,
+                        sleepMilliseconds: 100,
+                        throw: false,
+                    )
                     ->post(
                         url: 'https://api.pirsch.io/api/v1/'.($name === null ? 'hit' : 'event'),
                         data: [

--- a/src/Pirsch.php
+++ b/src/Pirsch.php
@@ -18,7 +18,7 @@ class Pirsch
 
             try {
                 Http::withToken(config('pirsch.token'))
-                    ->timeout(config('pirsch.timeout'))
+                    ->timeout(5)
                     ->retry(
                         times: 3,
                         sleepMilliseconds: 100,

--- a/src/Pirsch.php
+++ b/src/Pirsch.php
@@ -18,12 +18,7 @@ class Pirsch
 
             try {
                 Http::withToken(config('pirsch.token'))
-                    ->connectTimeout(0.5)
-                    ->retry(
-                        times: 3,
-                        sleepMilliseconds: 100,
-                        throw: false,
-                    )
+                    ->timeout(config('pirsch.timeout'))
                     ->post(
                         url: 'https://api.pirsch.io/api/v1/'.($name === null ? 'hit' : 'event'),
                         data: [


### PR DESCRIPTION
Due to a DDos attack at Pirsch Analytics my website was down. To avoid this case I would recommend to add a timeout (which is also configurable via .env) to prevent timeouts at the customer services. Also I don't find it very useful to add the retry option to increase the potential blocked request time. 

What do you think @zepfietje ?