### PR TITLE
Ignore Horizon routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ This package is the official Laravel integration for [Pirsch Analytics](https://
 
    PIRSCH_TOKEN=pa_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
    ```
+3. Publish the Pirsch config file if you wish to exclude specific routes:
+   ```bash
+   artisan vendor:publish --tag pirsch-config
+   ```
 
 ## Usage
 
@@ -25,7 +29,8 @@ This package is the official Laravel integration for [Pirsch Analytics](https://
 #### Automatically
 
 This package comes with a `TrackPageview` middleware that allows you to track pageviews automatically.
-Apply the middleware to your web routes by adding it to the `web` key of the `$middlewareGroups` property in your `app/Http/Kernel.php` class:
+Apply the middleware to your web routes by adding it to the `web` key of the `$middlewareGroups` property in
+your `app/Http/Kernel.php` class:
 
 ```php
 protected $middlewareGroups = [
@@ -51,7 +56,8 @@ Pirsch::track();
 
 ### Track events
 
-Pirsch allows you to [track custom events](https://docs.pirsch.io/dashboard/events) in order to measure additional information.
+Pirsch allows you to [track custom events](https://docs.pirsch.io/dashboard/events) in order to measure additional
+information.
 You can use the `Pirsch::track()` method with a name and optional metadata to track an event:
 
 ```php

--- a/config/pirsch.php
+++ b/config/pirsch.php
@@ -5,7 +5,7 @@ return [
     // If you wish you exclude dashboard routes, you'd add dashboard/
     'excluded_routes' => [
         'telescope/',
-        'horizon/'
-        // 'dashboard/'.
+        'horizon/',
+        // 'dashboard/'
     ],
 ];

--- a/config/pirsch.php
+++ b/config/pirsch.php
@@ -1,7 +1,11 @@
 <?php
 
 return [
-
-    'token' => env('PIRSCH_TOKEN'),
-
+    'token'           => env('PIRSCH_TOKEN'),
+    // If you wish you exclude dashboard routes, you'd add dashboard/
+    'excluded_routes' => [
+        'telescope/',
+        'horizon/'
+        // 'dashboard/'.
+    ],
 ];

--- a/src/Http/Middleware/TrackPageview.php
+++ b/src/Http/Middleware/TrackPageview.php
@@ -25,6 +25,10 @@ class TrackPageview
             return $response;
         }
 
+        if (str_starts_with($request->route()->uri, 'horizon/')) {
+            return $response;
+        }
+
         Pirsch::track();
 
         return $response;

--- a/src/Http/Middleware/TrackPageview.php
+++ b/src/Http/Middleware/TrackPageview.php
@@ -21,12 +21,10 @@ class TrackPageview
             return $response;
         }
 
-        if (str_starts_with($request->route()->uri, 'telescope/')) {
-            return $response;
-        }
-
-        if (str_starts_with($request->route()->uri, 'horizon/')) {
-            return $response;
+        foreach (config('pirsch.excluded_routes') as $route) {
+            if (str_starts_with($request->route()->uri, $route)) {
+                return $response;
+            }
         }
 
         Pirsch::track();


### PR DESCRIPTION
I noticed that the routes for Telescope were ignored and thought that it would also be good to exclude Horizons routes.