### PR TITLE
Improve Middleware except

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.0.0] - 2025-03-20
+
+### Added
+
+- Improve Middleware except.
 
 ## [0.4.10] - 2025-03-20
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ Apply the middleware to your web routes by appending it in the `withMiddleware` 
 })
 ```
 
+You can also apply the middleware to specific routes or groups:
+
+```php
+use Pirsch\Http\Middleware\TrackPageview;
+
+Route::middleware(TrackPageview::class)->group(function () {
+    Route::get('/', function () {
+        return view('welcome');
+    });
+});
+```
+
 #### Manually
 
 If you want to manually track pageviews instead, you can use the `Pirsch::track()` method.
@@ -74,7 +86,31 @@ Pirsch::track(
 
 You can configure the `TrackPageview` middleware to exclude specific pages from being tracked.
 
-Create a new middleware like this:
+On a specific rouute, you can exclude pages by adding a `except` property to the middleware class:
+
+```php
+use Pirsch\Http\Middleware\TrackPageview;
+
+Route::middleware(TrackPageview::class.':url/to/exclude/*')->group(function () {
+    Route::get('/', function () {
+        return view('welcome');
+    });
+});
+```
+
+Multiple urls can be excluded by separating them with a comma:
+
+```php
+use Pirsch\Http\Middleware\TrackPageview;
+
+Route::middleware(TrackPageview::class.':url/to/exclude/*,url/to/exclude2/*')->group(function () {
+    Route::get('/', function () {
+        return view('welcome');
+    });
+});
+```
+
+To exclude pages globally, you can create a new middleware that extends the `TrackPageview` middleware and add an `except` property:
 
 ```php
 namespace App\Http\Middleware;
@@ -89,7 +125,7 @@ class TrackPageview extends Middleware
      * @var array<int,string>
      */
     protected array $except = [
-        'url/to/exclude',
+        'url/to/exclude/*',
     ];
 
     /**

--- a/README.md
+++ b/README.md
@@ -33,8 +33,22 @@ This package is the official Laravel integration for [Pirsch Analytics](https://
 #### Automatically
 
 This package comes with a `TrackPageview` middleware that allows you to track pageviews automatically.
-Apply the middleware to your web routes by adding it to the `web` key of the `$middlewareGroups` property in your `app/Http/Kernel.php` class:
 
+Apply the middleware to your web routes by adding it to the `web` middleware group within your application's `bootstrap/app.php` file:
+```php
+use Pirsch\Http\Middleware\TrackPageview;
+     
+->withMiddleware(function (Middleware $middleware) {
+    $middleware->web(append: [
+        TrackPageview::class,
+    ]);
+})
+```
+
+<details>
+<summary>For Laravel <= 10.x</summary>
+Add the middleware to the <code>web</code> key of the <code>$middlewareGroups</code> property in your <code>app/Http/Kernel.php</code> class:
+    
 ```php
 protected $middlewareGroups = [
     'web' => [
@@ -45,6 +59,7 @@ protected $middlewareGroups = [
     // ...
 ];
 ```
+</details>
 
 #### Manually
 
@@ -109,8 +124,22 @@ class TrackPageview extends Middleware
 - `except` is an array with all URIs paths taht you want to exclude from tracking.
 - `exceptHeaders` is an array with all Headers that you want to exclude from tracking.
 
-Then replace the `TrackPageview` middleware with this on in your middleware configuration:
+Then replace the `TrackPageview` middleware with this one on your `bootstrap/app.php` middleware configuration:
 
+```php
+use App\Http\Middleware\TrackPageview;
+     
+->withMiddleware(function (Middleware $middleware) {
+    $middleware->web(append: [
+        TrackPageview::class,
+    ]);
+})
+```
+
+<details>
+<summary>For Laravel <= 10.x</summary>
+<code>app/Http/Kernel.php</code> file:
+    
 ```php
 protected $middlewareGroups = [
     'web' => [

--- a/README.md
+++ b/README.md
@@ -36,11 +36,9 @@ This package comes with a `TrackPageview` middleware that allows you to track pa
 Apply the middleware to your web routes by appending it in the `withMiddleware` method in your `bootstrap/app.php` file:
 
 ```php
-use Pirsch\Http\Middleware\TrackPageview;
-     
 ->withMiddleware(function (Middleware $middleware) {
     $middleware->web(append: [
-        TrackPageview::class,
+        \Pirsch\Http\Middleware\TrackPageview::class,
     ]);
 })
 ```
@@ -110,12 +108,11 @@ class TrackPageview extends Middleware
 
 Then replace the `TrackPageview` middleware with this one on your `bootstrap/app.php` middleware configuration:
 
-```php
-use App\Http\Middleware\TrackPageview;
-     
-->withMiddleware(function (Middleware $middleware) {
-    $middleware->web(append: [
-        TrackPageview::class,
-    ]);
-})
+```diff
+  ->withMiddleware(function (Middleware $middleware) {
+      $middleware->web(append: [
+-         \Pirsch\Http\Middleware\TrackPageview::class,
++         \App\Http\Middleware\TrackPageview::class,
+      ]);
+  })
 ```

--- a/README.md
+++ b/README.md
@@ -72,3 +72,52 @@ Pirsch::track(
     ],
 );
 ```
+
+### Filter pages
+
+You can configure the `TrackPageview` middleware to exclude specific pages from being tracked.
+
+Create a new middleware like this:
+
+```php
+namespace App\Http\Middleware;
+
+use Pirsch\Http\Middleware\TrackPageview as Middleware;
+
+class TrackPageview extends Middleware
+{
+    /**
+     * The URIs that should be excluded from tracking.
+     *
+     * @var array<int,string>
+     */
+    protected array $except = [
+        'url/to/exclude',
+    ];
+
+    /**
+     * The Headers that should be excluded from tracking.
+     *
+     * @var array<int,string>
+     */
+    protected array $exceptHeaders = [
+        'X-ExcludedHeader',
+    ];
+}
+```
+
+- `except` is an array with all URIs paths taht you want to exclude from tracking.
+- `exceptHeaders` is an array with all Headers that you want to exclude from tracking.
+
+Then replace the `TrackPageview` middleware with this on in your middleware configuration:
+
+```php
+protected $middlewareGroups = [
+    'web' => [
+        // ...
+        \App\Http\Middleware\TrackPageview::class,
+    ],
+
+    // ...
+];
+```

--- a/src/Facades/Pirsch.php
+++ b/src/Facades/Pirsch.php
@@ -13,6 +13,6 @@ class Pirsch extends Facade
 {
     protected static function getFacadeAccessor()
     {
-        return 'laravel-pirsch';
+        return \Pirsch\Facades\Pirsch::class;
     }
 }

--- a/src/Http/Middleware/TrackPageview.php
+++ b/src/Http/Middleware/TrackPageview.php
@@ -9,6 +9,28 @@ use Pirsch\Facades\Pirsch;
 
 class TrackPageview
 {
+    /**
+     * The URIs that should be excluded from tracking.
+     *
+     * @var array<int,string>
+     */
+    protected array $except = [
+        'telescope',
+        'horizon',
+    ];
+
+    /**
+     * The Headers that should be excluded from tracking.
+     *
+     * @var array<int,string>
+     */
+    protected array $exceptHeaders = [
+        'X-Livewire',
+    ];
+
+    /**
+     * Handle an incoming request.
+     */
     public function handle(Request $request, Closure $next): mixed
     {
         $response = $next($request);
@@ -17,16 +39,44 @@ class TrackPageview
             return $response;
         }
 
-        if ($request->hasHeader('X-Livewire')) {
-            return $response;
+        if (! $this->inExceptArray($request) &&
+            ! $this->inExceptHeadersArray($request)
+        ) {
+            Pirsch::track();
         }
-
-        if (str_starts_with($request->route()->uri, 'telescope/')) {
-            return $response;
-        }
-
-        Pirsch::track();
 
         return $response;
+    }
+
+    /**
+     * Determine if the request has a header that should not be tracked.
+     */
+    protected function inExceptHeadersArray(Request $request): bool
+    {
+        foreach ($this->exceptHeaders as $except) {
+            if ($request->hasHeader($except)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine if the request has a URI that should not be tracked.
+     */
+    protected function inExceptArray(Request $request): bool
+    {
+        foreach ($this->except as $except) {
+            if ($except !== '/') {
+                $except = trim($except, '/');
+            }
+
+            if ($request->fullUrlIs($except) || $request->is($except)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Http/Middleware/TrackPageview.php
+++ b/src/Http/Middleware/TrackPageview.php
@@ -15,8 +15,8 @@ class TrackPageview
      * @var array<int,string>
      */
     protected array $except = [
-        'telescope',
-        'horizon',
+        'telescope/*',
+        'horizon/*',
     ];
 
     /**
@@ -31,7 +31,7 @@ class TrackPageview
     /**
      * Handle an incoming request.
      */
-    public function handle(Request $request, Closure $next): mixed
+    public function handle(Request $request, Closure $next, string ...$excepts): mixed
     {
         $response = $next($request);
 
@@ -39,7 +39,7 @@ class TrackPageview
             return $response;
         }
 
-        if (! $this->inExceptArray($request) &&
+        if (! $this->inExceptArray($request, $excepts) &&
             ! $this->inExceptHeadersArray($request)
         ) {
             Pirsch::track();
@@ -65,9 +65,9 @@ class TrackPageview
     /**
      * Determine if the request has a URI that should not be tracked.
      */
-    protected function inExceptArray(Request $request): bool
+    protected function inExceptArray(Request $request, array $excepts = null): bool
     {
-        foreach ($this->except as $except) {
+        foreach (empty($excepts) ? $this->except : $excepts as $except) {
             if ($except !== '/') {
                 $except = trim($except, '/');
             }

--- a/src/Http/Middleware/TrackPageview.php
+++ b/src/Http/Middleware/TrackPageview.php
@@ -65,7 +65,7 @@ class TrackPageview
     /**
      * Determine if the request has a URI that should not be tracked.
      */
-    protected function inExceptArray(Request $request, array $excepts = null): bool
+    protected function inExceptArray(Request $request, ?array $excepts = null): bool
     {
         foreach (empty($excepts) ? $this->except : $excepts as $except) {
             if ($except !== '/') {

--- a/src/PirschServiceProvider.php
+++ b/src/PirschServiceProvider.php
@@ -16,6 +16,9 @@ class PirschServiceProvider extends PackageServiceProvider
 
     public function packageRegistered(): void
     {
-        $this->app->bind('laravel-pirsch', fn () =>  new Pirsch());
+        $this->app->bind(
+            \Pirsch\Facades\Pirsch::class,
+            \Pirsch\Pirsch::class
+        );
     }
 }

--- a/tests/TrackPageviewTest.php
+++ b/tests/TrackPageviewTest.php
@@ -22,7 +22,7 @@ it('skips redirects', function () {
 
     $this->get('/');
 
-    Pirsch::shouldNotHaveBeenCalled();
+    Pirsch::shouldNotHaveReceived('track');
 });
 
 it('skips Livewire', function () {
@@ -33,18 +33,18 @@ it('skips Livewire', function () {
 
     $this->get('/', ['X-Livewire' => 'true']);
 
-    Pirsch::shouldNotHaveBeenCalled();
+    Pirsch::shouldNotHaveReceived('track');
 });
 
 it('skips Telescope', function () {
     Pirsch::spy();
 
     Route::middleware(TrackPageview::class)
-        ->get('telescope/test', fn () => 'Hello World');
+        ->get('/telescope/test', fn () => 'Hello World');
 
     $this->get('/telescope/test');
 
-    Pirsch::shouldNotHaveBeenCalled();
+    Pirsch::shouldNotHaveReceived('track');
 });
 
 it('skips Horizon', function () {
@@ -55,5 +55,16 @@ it('skips Horizon', function () {
 
     $this->get('/horizon/test');
 
-    Pirsch::shouldNotHaveBeenCalled();
+    Pirsch::shouldNotHaveReceived('track');
+});
+
+it('skips parameter except', function () {
+    Pirsch::spy();
+
+    Route::middleware(TrackPageview::class.':myurl/*')
+        ->get('myurl/test', fn () => 'Hello World');
+
+    $this->get('/myurl/test');
+
+    Pirsch::shouldNotHaveReceived('track');
 });

--- a/tests/TrackPageviewTest.php
+++ b/tests/TrackPageviewTest.php
@@ -46,3 +46,14 @@ it('skips Telescope', function () {
 
     Pirsch::shouldNotHaveBeenCalled();
 });
+
+it('skips Horizon', function () {
+    Pirsch::spy();
+
+    Route::middleware(TrackPageview::class)
+        ->get('horizon/test', fn () => 'Hello World');
+
+    $this->get('/horizon/test');
+
+    Pirsch::shouldNotHaveBeenCalled();
+});


### PR DESCRIPTION
This is inspired by [https://github.com/laravel/framework/blob/master/src/Illuminate/Foundation/Http/Middleware/Concerns/ExcludesPaths.php](ExcludesPaths.php) trait (from Laravel 11.x) used in `TrustProxies` middleware.

This allows you to extends `TrackPageview` middleware like:
```php
namespace App\Http\Middleware;

use Pirsch\Http\Middleware\TrackPageview as Middleware;

class TrackPageview extends Middleware
{
    /**
     * The URIs that should be excluded from tracking.
     *
     * @var array<int,string>
     */
    protected array $except = [
        'my/url',
    ];
}
```